### PR TITLE
Enable verifying wallet password with having to load wallet

### DIFF
--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -125,6 +125,10 @@ bool WalletManagerImpl::walletExists(const std::string &path)
     return false;
 }
 
+bool WalletManagerImpl::verifyWalletPassword(const std::string &keys_file_name, const std::string &password, const bool watch_only)
+{
+	    return tools::wallet2::verify_password(keys_file_name, password, watch_only);
+}
 
 std::vector<std::string> WalletManagerImpl::findWallets(const std::string &path)
 {

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -50,6 +50,7 @@ public:
                                                     const std::string &spendKeyString = "");
     virtual bool closeWallet(Wallet *wallet);
     bool walletExists(const std::string &path);
+    bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, const bool watch_only);
     std::vector<std::string> findWallets(const std::string &path);
     std::string errorString() const;
     void setDaemonAddress(const std::string &address);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2103,7 +2103,22 @@ bool wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
  */
 bool wallet2::verify_password(const std::string& password) const
 {
-  const std::string keys_file_name = m_keys_file;
+  return verify_password(m_keys_file, password, m_watch_only);
+}
+
+/*!
+ * \brief verify password for specified wallet keys file.
+ * \param keys_file_name  Keys file to verify password for
+ * \param password        Password to verify
+ * \param watch_only      If set = only verify view keys, otherwise also spend keys
+ *
+ * for verification only
+ * should not mutate state, unlike load_keys()
+ * can be used prior to rewriting wallet keys file, to ensure user has entered the correct password
+ *
+ */
+bool wallet2::verify_password(const std::string& keys_file_name, const std::string& password, const bool watch_only)
+{
   wallet2::keys_file_data keys_file_data;
   std::string buf;
   bool r = epee::file_io_utils::load_file_to_string(keys_file_name, buf);
@@ -2136,7 +2151,7 @@ bool wallet2::verify_password(const std::string& password) const
   const cryptonote::account_keys& keys = account_data_check.get_keys();
 
   r = r && verify_keys(keys.m_view_secret_key,  keys.m_account_address.m_view_public_key);
-  if(!m_watch_only)
+  if(!watch_only)
     r = r && verify_keys(keys.m_spend_secret_key, keys.m_account_address.m_spend_public_key);
   return r;
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -129,6 +129,8 @@ namespace tools
     //! Just parses variables.
     static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm);
 
+    static bool verify_password(const std::string& keys_file_name, const std::string& password, const bool watch_only);
+
     wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
 
     struct transfer_details

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -667,6 +667,15 @@ struct WalletManager
     virtual bool walletExists(const std::string &path) = 0;
 
     /*!
+     * @brief verifyWalletPassword - check if the given filename is the wallet
+     * @param keys_file_name - location of keys file
+     * @param password - password to verify
+     * @param watch_only - verify only view keys?
+     * @return
+     */
+    virtual bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, const bool watch_only) = 0;
+
+    /*!
      * \brief findWallets - searches for the wallet files by given path name recursively
      * \param path - starting point to search
      * \return - list of strings with found wallets (absolute paths);


### PR DESCRIPTION
Current implementation requires wallet to be opened to validate a password. This patch allows verifying directly on the keys file by reusing wallet2 code. Also adds appropriate method to the WalletManager API.