### PR TITLE
store is optional during close and defaults to true; except during de…

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -302,7 +302,7 @@ WalletImpl::~WalletImpl()
     // Pause refresh thread - prevents refresh from starting again
     pauseRefresh();
     // Close wallet - stores cache and stops ongoing refresh operation 
-    close();
+    close(false); // do not store wallet as part of the closing activities
     // Stop refresh thread
     stopRefresh();
     delete m_wallet2Callback;
@@ -538,19 +538,21 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
     return m_status == Status_Ok;
 }
 
-bool WalletImpl::close()
+bool WalletImpl::close(bool store)
 {
 
     bool result = false;
     LOG_PRINT_L1("closing wallet...");
     try {
-        // Do not store wallet with invalid status
-        // Status Critical refers to errors on opening or creating wallets.
-        if (status() != Status_Critical)
-            m_wallet->store();
-        else
-            LOG_ERROR("Status_Critical - not storing wallet");
-        LOG_PRINT_L1("wallet::store done");
+        if (store) {
+            // Do not store wallet with invalid status
+            // Status Critical refers to errors on opening or creating wallets.
+            if (status() != Status_Critical)
+                m_wallet->store();
+            else
+                LOG_ERROR("Status_Critical - not storing wallet");
+            LOG_PRINT_L1("wallet::store done");
+        }
         LOG_PRINT_L1("Calling wallet::stop...");
         m_wallet->stop();
         LOG_PRINT_L1("wallet::stop done");

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -63,7 +63,7 @@ public:
                             const std::string &address_string, 
                             const std::string &viewkey_string,
                             const std::string &spendkey_string = "");
-    bool close();
+    bool close(bool store = true);
     std::string seed() const;
     std::string getSeedLanguage() const;
     void setSeedLanguage(const std::string &arg);

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -102,10 +102,10 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
     return wallet;
 }
 
-bool WalletManagerImpl::closeWallet(Wallet *wallet)
+bool WalletManagerImpl::closeWallet(Wallet *wallet, bool store)
 {
     WalletImpl * wallet_ = dynamic_cast<WalletImpl*>(wallet);
-    bool result = wallet_->close();
+    bool result = wallet_->close(store);
     if (!result) {
         m_errorString = wallet_->errorString();
     } else {

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -48,7 +48,7 @@ public:
                                                     const std::string &addressString,
                                                     const std::string &viewKeyString,
                                                     const std::string &spendKeyString = "");
-    virtual bool closeWallet(Wallet *wallet);
+    virtual bool closeWallet(Wallet *wallet, bool store = true);
     bool walletExists(const std::string &path);
     std::vector<std::string> findWallets(const std::string &path);
     std::string errorString() const;

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -653,7 +653,7 @@ struct WalletManager
      * \param wallet        previously opened / created wallet instance
      * \return              None
      */
-    virtual bool closeWallet(Wallet *wallet) = 0;
+    virtual bool closeWallet(Wallet *wallet, bool store) = 0;
 
     /*
      * ! checks if wallet with the given name already exists


### PR DESCRIPTION
…struction

close should not store unconditionally. otherwise there is no possibility to close without store.
also, the destructor calls close() which in turn stores the wallet - this takes a long time with no possibility of error detection/correction. destructors should not be persisting data.
the API Wallet closes and then deletes the WalletImpl on success which actually stores the wallet again (!!) wasting even more time.