### PR TITLE
Recover with password

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -391,10 +391,20 @@ bool WalletImpl::createWatchOnly(const std::string &path, const std::string &pas
 }
 
 bool WalletImpl::recoverFromKeys(const std::string &path,
-                                const std::string &language,
-                                const std::string &address_string,
-                                const std::string &viewkey_string,
-                                const std::string &spendkey_string)
+                                 const std::string &language,
+                                 const std::string &address_string,
+                                 const std::string &viewkey_string,
+                                 const std::string &spendkey_string)
+{
+    return recoverWithKeys(path, "", language, address_string, viewkey_string, spendkey_string);
+}
+
+bool WalletImpl::recoverWithKeys(const std::string &path,
+                                 const std::string &password,
+                                 const std::string &language,
+                                 const std::string &address_string,
+                                 const std::string &viewkey_string,
+                                 const std::string &spendkey_string)
 {
     cryptonote::account_public_address address;
     bool has_payment_id;
@@ -464,12 +474,12 @@ bool WalletImpl::recoverFromKeys(const std::string &path,
     try
     {
         if (has_spendkey) {
-            m_wallet->generate(path, "", address, spendkey, viewkey);
+            m_wallet->generate(path, password, address, spendkey, viewkey);
             setSeedLanguage(language);
             LOG_PRINT_L1("Generated new wallet from keys with seed language: " + language);
         }
         else {
-            m_wallet->generate(path, "", address, viewkey);
+            m_wallet->generate(path, password, address, viewkey);
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         
@@ -510,6 +520,11 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
 
 bool WalletImpl::recover(const std::string &path, const std::string &seed)
 {
+    return recover(path, "", seed);
+}
+
+bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed)
+{
     clearStatus();
     m_errorString.clear();
     if (seed.empty()) {
@@ -530,7 +545,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
 
     try {
         m_wallet->set_seed_language(old_language);
-        m_wallet->generate(path, "", recovery_key, true, false);
+        m_wallet->generate(path, password, recovery_key, true, false);
 
     } catch (const std::exception &e) {
         m_status = Status_Critical;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -57,7 +57,18 @@ public:
     bool createWatchOnly(const std::string &path, const std::string &password,
                             const std::string &language) const;
     bool open(const std::string &path, const std::string &password);
+    bool recover(const std::string &path,const std::string &password,
+                            const std::string &seed);
+    bool recoverWithKeys(const std::string &path,
+                            const std::string &password,
+                            const std::string &language,
+                            const std::string &address_string, 
+                            const std::string &viewkey_string,
+                            const std::string &spendkey_string = "");
+    // following two methods are deprecated since they create passwordless wallets
+    // use the two equivalent methods above
     bool recover(const std::string &path, const std::string &seed);
+    // deprecated: use recoverWithKeys instead
     bool recoverFromKeys(const std::string &path,
                             const std::string &language,
                             const std::string &address_string, 

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -76,17 +76,42 @@ Wallet *WalletManagerImpl::openWallet(const std::string &path, const std::string
     return wallet;
 }
 
-Wallet *WalletManagerImpl::recoveryWallet(const std::string &path, const std::string &memo, bool testnet, uint64_t restoreHeight)
+Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
+                                                const std::string &memo,
+                                                bool testnet,
+                                                uint64_t restoreHeight)
+{
+    return recoveryWallet(path, "", memo, testnet, restoreHeight);
+}
+
+Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path, 
+                                                const std::string &language,
+                                                bool testnet, 
+                                                uint64_t restoreHeight,
+                                                const std::string &addressString,
+                                                const std::string &viewKeyString,
+                                                const std::string &spendKeyString)
+{
+    return createWalletWithKeys(path, "", language, testnet, restoreHeight,
+                                addressString, viewKeyString, spendKeyString);
+} 
+
+Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
+                                                const std::string &password,
+                                                const std::string &memo,
+                                                bool testnet,
+                                                uint64_t restoreHeight)
 {
     WalletImpl * wallet = new WalletImpl(testnet);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recover(path, memo);
+    wallet->recover(path, password, memo);
     return wallet;
 }
 
-Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path, 
+Wallet *WalletManagerImpl::createWalletWithKeys(const std::string &path, 
+                                                const std::string &password,
                                                 const std::string &language,
                                                 bool testnet, 
                                                 uint64_t restoreHeight,
@@ -98,7 +123,7 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recoverFromKeys(path, language, addressString, viewKeyString, spendKeyString);
+    wallet->recoverWithKeys(path, password, language, addressString, viewKeyString, spendKeyString);
     return wallet;
 }
 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -40,14 +40,32 @@ public:
     Wallet * createWallet(const std::string &path, const std::string &password,
                           const std::string &language, bool testnet);
     Wallet * openWallet(const std::string &path, const std::string &password, bool testnet);
-    virtual Wallet * recoveryWallet(const std::string &path, const std::string &memo, bool testnet, uint64_t restoreHeight);
+    virtual Wallet * recoveryWallet(const std::string &path,
+                                       const std::string &password,
+                                       const std::string &memo,
+                                       bool testnet,
+                                       uint64_t restoreHeight);
+    virtual Wallet * createWalletWithKeys(const std::string &path, 
+                                             const std::string &password,
+                                             const std::string &language,
+                                             bool testnet, 
+                                             uint64_t restoreHeight,
+                                             const std::string &addressString,
+                                             const std::string &viewKeyString,
+                                             const std::string &spendKeyString = "");
+    // next two methods are deprecated - use the above version which allow setting of a password
+    virtual Wallet * recoveryWallet(const std::string &path,
+                                       const std::string &memo,
+                                       bool testnet,
+                                       uint64_t restoreHeight);
+    // deprecated: use createWalletWithKeys instead
     virtual Wallet * createWalletFromKeys(const std::string &path, 
-                                                    const std::string &language,
-                                                    bool testnet, 
-                                                    uint64_t restoreHeight,
-                                                    const std::string &addressString,
-                                                    const std::string &viewKeyString,
-                                                    const std::string &spendKeyString = "");
+                                             const std::string &language,
+                                             bool testnet, 
+                                             uint64_t restoreHeight,
+                                             const std::string &addressString,
+                                             const std::string &viewKeyString,
+                                             const std::string &spendKeyString = "");
     virtual bool closeWallet(Wallet *wallet, bool store = true);
     bool walletExists(const std::string &path);
     bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool watch_only) const;

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -632,6 +632,18 @@ struct WalletManager
     /*!
      * \brief  recovers existing wallet using memo (electrum seed)
      * \param  path           Name of wallet file to be created
+     * \param  password       Password of wallet file
+     * \param  memo           memo (25 words electrum seed)
+     * \param  testnet        testnet
+     * \param  restoreHeight  restore from start height
+     * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+     */
+    virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &memo, bool testnet = false, uint64_t restoreHeight = 0) = 0;
+
+    /*!
+     * \deprecated this method creates a wallet WITHOUT a psssphrase, use the alternate recoverWallet() method
+     * \brief  recovers existing wallet using memo (electrum seed)
+     * \param  path           Name of wallet file to be created
      * \param  memo           memo (25 words electrum seed)
      * \param  testnet        testnet
      * \param  restoreHeight  restore from start height
@@ -639,18 +651,40 @@ struct WalletManager
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &memo, bool testnet = false, uint64_t restoreHeight = 0) = 0;
 
-   /*!
-    * \brief  recovers existing wallet using keys. Creates a view only wallet if spend key is omitted
-    * \param  path           Name of wallet file to be created
-    * \param  language       language
-    * \param  testnet        testnet
-    * \param  restoreHeight  restore from start height
-    * \param  addressString  public address
-    * \param  viewKeyString  view key
-    * \param  spendKeyString spend key (optional)
-    * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
-    */
-    virtual Wallet * createWalletFromKeys(const std::string &path, 
+    /*!
+     * \brief  recovers existing wallet using keys. Creates a view only wallet if spend key is omitted
+     * \param  path           Name of wallet file to be created
+     * \param  password       Password of wallet file
+     * \param  language       language
+     * \param  testnet        testnet
+     * \param  restoreHeight  restore from start height
+     * \param  addressString  public address
+     * \param  viewKeyString  view key
+     * \param  spendKeyString spend key (optional)
+     * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+     */
+     virtual Wallet * createWalletWithKeys(const std::string &path, 
+                                                    const std::string &password,
+                                                    const std::string &language,
+                                                    bool testnet, 
+                                                    uint64_t restoreHeight,
+                                                    const std::string &addressString,
+                                                    const std::string &viewKeyString,
+                                                    const std::string &spendKeyString = "") = 0;
+
+    /*!
+     * \deprecated this method creates a wallet WITHOUT a psssphrase, use createWalletWithKeys() instead
+     * \brief  recovers existing wallet using keys. Creates a view only wallet if spend key is omitted
+     * \param  path           Name of wallet file to be created
+     * \param  language       language
+     * \param  testnet        testnet
+     * \param  restoreHeight  restore from start height
+     * \param  addressString  public address
+     * \param  viewKeyString  view key
+     * \param  spendKeyString spend key (optional)
+     * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+     */
+     virtual Wallet * createWalletFromKeys(const std::string &path, 
                                                     const std::string &language,
                                                     bool testnet, 
                                                     uint64_t restoreHeight,


### PR DESCRIPTION
Recovering from keys or seed created a wallet on disk with no password. Any attacker watching the wallet directory could copy away such a file for future use. These creation methods were marked as deprecated and new methods implemented which accept a password parameter. Unfortunately, a password parameter could not simply be added to recoverFromKeys() as that would ambiguate the call (the last parm <spendkey_string> is optional) so the new method was called recoverWithKeys().

Tested with monerujo.